### PR TITLE
fix map

### DIFF
--- a/src/components/Map.astro
+++ b/src/components/Map.astro
@@ -9,15 +9,15 @@ const key = process.env.GOOGLE_API_KEY;
     }
 </style>
 
-<iframe id="map"/>
+<iframe id="map"></iframe>
 
 <script define:vars={{ key }}>
-    const $map = document.getElementById('map');
-    const url = new URL('/maps/embed/v1/search', 'https://www.google.com');
-    url.searchParams.append('key', key);
-    window.addEventListener('city', ({ detail: city }) => {
-        const q = encodeURIComponent(`pickleball courts ${city}`);
-        url.searchParams.append('q', q);
+    const $map = document.getElementById("map");
+    window.addEventListener("city", ({ detail: city }) => {
+        const url = new URL("/maps/embed/v1/search", "https://www.google.com");
+        url.searchParams.append("key", key);
+        const q = `pickleball courts ${city}`;
+        url.searchParams.append("q", q);
         $map.src = url.toString();
     });
 </script>


### PR DESCRIPTION
CC: @ddamato 

two issues fixed:
- google maps embed doesn't actually need `encodeURIComponent`. It deals with spaces better than escaped spaces
- the `url` object needs to be inside the event listener handler or else it always references the same one and each new city keeps being appended to the previous `url.searchParams` leading to stuff like `q=New York+Seattle+Boston`.

The formatting changes are just prettier doing its thing.