### PR TITLE
Better desktop layout

### DIFF
--- a/src/components/Calendar.astro
+++ b/src/components/Calendar.astro
@@ -57,7 +57,7 @@
   }
 </style>
 
-<details>
+<details id="details">
   <summary id="summary"></summary>
   <table>
     <thead id="thead"></thead>

--- a/src/components/Calendar.astro
+++ b/src/components/Calendar.astro
@@ -3,6 +3,7 @@
     background-color: color-mix(in srgb, var(--background-color), black 5%);
     border-radius: 0.5rem;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    grid-area: calendar;
   }
 
   summary {

--- a/src/components/Content.astro
+++ b/src/components/Content.astro
@@ -7,6 +7,7 @@
         gap: 1rem;
         align-items: center;
         isolation: isolate;
+        padding: 2rem;
     }
 
     .card {
@@ -20,8 +21,7 @@
         border: 1px solid color-mix(in srgb, var(--background-color), white 10%);
         backdrop-filter: blur(4px);
         padding: 2rem;
-        max-width: 600px;
-        width: 90%;
+        max-width: 900px;
         isolation: isolate;
         display: flex;
         flex-direction: column;

--- a/src/components/Grid.astro
+++ b/src/components/Grid.astro
@@ -1,13 +1,16 @@
 <style>
     #grid {
         display: grid;
-        grid-template-areas: 'results map' 'calendar map';
+        grid-template-areas: 'results calendar' 'map calendar';
+        grid-template-columns: 1fr 1fr;
         gap: 1rem;
+        align-items: start;
     }
 
     @media (max-width: 700px) {
         #grid {
             grid-template-areas: 'results' 'calendar' 'map';
+            grid-template-columns: 1fr;
         }
     }
 </style>

--- a/src/components/Grid.astro
+++ b/src/components/Grid.astro
@@ -3,6 +3,7 @@
         display: grid;
         grid-template-areas: 'results calendar' 'map calendar';
         grid-template-columns: 1fr 1fr;
+        grid-template-rows: auto 1fr;
         gap: 1rem;
         align-items: start;
     }

--- a/src/components/Grid.astro
+++ b/src/components/Grid.astro
@@ -1,0 +1,17 @@
+<style>
+    #grid {
+        display: grid;
+        grid-template-areas: 'results map' 'calendar map';
+        gap: 1rem;
+    }
+
+    @media (max-width: 700px) {
+        #grid {
+            grid-template-areas: 'results' 'calendar' 'map';
+        }
+    }
+</style>
+
+<div id="grid">
+    <slot/>
+</div>

--- a/src/components/Map.astro
+++ b/src/components/Map.astro
@@ -6,10 +6,9 @@ const key = process.env.GOOGLE_API_KEY;
     iframe {
         border: 0;
         height: 0;
-    }
-
-    iframe[src] {
-        height: 400px;
+        grid-area: map;
+        height: 100%;
+        max-width: 400px;
     }
 </style>
 

--- a/src/components/Map.astro
+++ b/src/components/Map.astro
@@ -8,7 +8,8 @@ const key = process.env.GOOGLE_API_KEY;
         height: 0;
         grid-area: map;
         height: 100%;
-        max-width: 400px;
+        width: 100%;
+        min-height: 400px;
     }
 </style>
 

--- a/src/components/Results.astro
+++ b/src/components/Results.astro
@@ -6,6 +6,7 @@
     padding: 1.5rem;
     margin: 0;
     line-height: 1.8;
+    grid-area: results;
   }
 </style>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import Scene from '@components/Scene.astro';
 import Content from '@components/Content.astro';
 import Headline from '@components/Headline.astro';
 import WeatherCriteria from '@components/WeatherCriteria.astro';
+import Grid from '@components/Grid.astro';
 import Results from '@components/Results.astro';
 import Calendar from '@components/Calendar.astro';
 import Map from '@components/Map.astro';
@@ -14,8 +15,10 @@ import Map from '@components/Map.astro';
     <Content>
         <Headline/>
         <WeatherCriteria/>
-        <Results/>
-        <Calendar/>
-        <Map/>
+        <Grid>
+            <Results/>
+            <Calendar/>
+            <Map/>
+        </Grid>
     </Content>
 </Layout>

--- a/src/scripts/calendar.js
+++ b/src/scripts/calendar.js
@@ -2,6 +2,7 @@ import getWeatherEmoji from "./emoji.js";
 import { START_HOUR, END_HOUR } from "./hours.js";
 
 const DAYS_SHOWN = 3;
+const $details = document.getElementById('details');
 const $summary = document.getElementById('summary');
 const $thead = document.getElementById('thead');
 const $tbody = document.getElementById('tbody');
@@ -93,6 +94,19 @@ function clearCalendar() {
     });
 }
 
+/**
+ * Toggles the details element.
+ * 
+ * @param {Event} ev - Native Event Object.
+ */
+function detailsToggle(ev) {
+    if (ev.matches) {
+        $details.removeAttribute('open');
+    } else {
+        $details.setAttribute('open', '');
+    }
+}
+
 renderCalendar();
 
 window.addEventListener("forecasts", ({ detail: forecasts }) => {
@@ -105,3 +119,7 @@ window.addEventListener("forecasts", ({ detail: forecasts }) => {
         cell.textContent = `${getWeatherEmoji(shortForecast)} ${temperature}`;
     });
 });
+
+const mq = window.matchMedia('(max-width: 700px)');
+mq.addEventListener('change', detailsToggle);
+detailsToggle(mq);


### PR DESCRIPTION
Satisfies: https://github.com/stanchanpsu/whencanipickle/issues/34


- Uses CSS grid to reflow content between desktop/mobile (breakpoint at 700px) between all the resulting items.

Might need some direction for when the calendar cells are open, the screen is exceptionally long.