### PR TITLE
fix: result box background invisible in light mode, remove alternating row colors

### DIFF
--- a/src/components/Calendar.astro
+++ b/src/components/Calendar.astro
@@ -39,11 +39,7 @@
     border-collapse: collapse;
   }
 
-  table :global(tr:nth-child(even)) {
-    background-color: var(--background-color);
-  }
-
-  table :global(tr:nth-child(odd)) {
+  table :global(tr) {
     background-color: color-mix(in srgb, var(--background-color), black 5%);
   }
 

--- a/src/components/Results.astro
+++ b/src/components/Results.astro
@@ -1,7 +1,7 @@
 <style>
   p {
     white-space: pre-line;
-    background-color: color-mix(in srgb, var(--background-color), white 10%);
+    background-color: color-mix(in srgb, var(--background-color), black 5%);
     border-radius: 0.5rem;
     padding: 1.5rem;
     margin: 0;


### PR DESCRIPTION
Fixes two UI issues:

1. **Result box background invisible in light mode** — Changed `white 10%` to `black 5%` in `Results.astro` so the result box has a subtle light gray background instead of pure white, making it visible against the card.

2. **Remove alternating row colors on calendar table** — Collapsed the `nth-child(even)` / `nth-child(odd)` rules into a single `tr` rule. Result cells with good/bad weather indicators already color themselves independently, so the alternating pattern was unnecessary.